### PR TITLE
Correctie twee records in kohier1887.tsv

### DIFF
--- a/kohier1887.tsv
+++ b/kohier1887.tsv
@@ -69,7 +69,7 @@
 2		"Scheepmakersdijk"	61	"A. J."	"Jansen"	6	6	375	12
 2		"Scheepmakersdijk"	2	"D. van"	"Seggelen"	5	9	75	2,4
 2		"Scheepmakersdijk"	"4a"	"*H. J. van"	"Muijen"	3	3	100	3,2
-2		"Scheepmakersdijk"	"4a"	"rood *F. W."	"Pits"	2	1	100	3,2
+2		"Scheepmakersdijk"	"4arood"	"*F. W."	"Pits"	2	1	100	3,2
 2		"Scheepmakersdijk"	"4b"	"*A. v. d."	"Bijl"	3	4	50	1,6
 2		"Scheepmakersdijk"	"4f"	"  van"	"Hooff"	3	1	200	6,4
 2		"Scheepmakersdijk"	8	"*J."	"Slenders"	4	1	325	10,4
@@ -1323,7 +1323,7 @@
 26		"Anegang"	20	"Mej. A. de"	"Block"	1	0	50	1,6
 26		"Anegang"	"20a"	"H."	"Hassink"	7	2	725	23,2
 26		"Anegang"	"20a"	"Mej. C."	"Zeller"	1	0	50	1,6
-26		"Anegang"	"20a"	"rood J."	"Reerink"	11	2	1900	60,8
+26		"Anegang"	"20arood"	"J."	"Reerink"	11	2	1900	60,8
 26		"Anegang"	22	"J."	"Wassmann"	9	2	1250	40
 26		"Anegang"	22	"J. M. v."	"Leuven"	"A"	0	150	4,8
 26		"Anegang"	24	"B."	"Oosten"	10	2	1550	49,6


### PR DESCRIPTION
Bij 2 records staat de markering "rood" in de kolom van de voorletters in plaats van de huisnummers.
